### PR TITLE
Proc83/friend page refactors

### DIFF
--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -277,7 +277,15 @@ void _pokeFriend(String friendUID) async {
                   ),
                   builder: (context) => const PokeNotificationsPage(),
                 );
-              } else {
+              } else if (index == 0) { // If "Add Friends" is tapped
+            showModalBottomSheet(
+              context: context,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+              ),
+              builder: (context) => const ShowAddFriendsSheet(),
+            );
+          } else {
                 setState(() {
                   _selectedIndex = index;
                 });
@@ -285,12 +293,16 @@ void _pokeFriend(String friendUID) async {
             },
             items: const [
               BottomNavigationBarItem(
-                icon: Icon(Icons.home),
+                icon: Icon(Icons.person_add_alt_1),
                 label: 'Add Friends',
               ),
               BottomNavigationBarItem(
                 icon: Icon(Icons.waving_hand),
                 label: 'Pokes',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.person_pin_rounded),
+                label: 'Friend Requests',
               ),
             ],
           )
@@ -355,3 +367,63 @@ class PokeNotificationsPage extends StatelessWidget {
 }
 
 
+///*********************************************************
+/// Name: ShowAddFriendsSheet
+/// 
+/// Description: Displays a bottom sheet for adding friends.
+/// Contains a search bar, the user's profile picture, and a 
+/// button to copy their UID.
+///*********************************************************
+class ShowAddFriendsSheet extends StatelessWidget {
+  const ShowAddFriendsSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final FirebaseAuth auth = FirebaseAuth.instance;
+    final FirebaseFirestore firestore = FirebaseFirestore.instance;
+    final TextEditingController _searchController = TextEditingController();
+    
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // User profile picture
+          CircleAvatar(
+            radius: 50,
+            backgroundImage: NetworkImage(auth.currentUser?.photoURL ?? 'https://picsum.photos/200/200'),
+          ),
+          const SizedBox(height: 16),
+
+          // Copy UID button
+          TextButton.icon(
+            icon: const Icon(Icons.copy),
+            label: const Text("Copy UID"),
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: auth.currentUser?.uid ?? ""));
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('UID copied to clipboard!'))
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+
+          // Friend search bar
+          TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              labelText: 'Enter Friend UID',
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  // Call add friend function here
+                  // Example: _addFriend(_searchController.text);
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -90,19 +90,35 @@ class _FriendsListState extends State<FriendsList>{
   }
  
   CollectionReference uidCollection = _firestore.collection('UID');
-
   DocumentSnapshot friendDocRef = await uidCollection.doc(friendUID).get();
 
   if (friendDocRef.exists) { // This will be true even if the document has no fields
-    DocumentReference userDocRef = _firestore.collection('UID').doc(_auth.currentUser?.uid);
+    DocumentReference friendsRequests = uidCollection
+          .doc(friendUID)
+          .collection('friend_requests')
+          .doc(_auth.currentUser?.uid);
 
-    await userDocRef.set({
-      'friends': FieldValue.arrayUnion([friendUID])
-    }, SetOptions(merge: true));
+      await friendsRequests.set({
+        'from': _auth.currentUser?.uid,
+        'timestamp': FieldValue.serverTimestamp(),
+      });
 
-    await userDocRef.collection('friends').doc(friendUID).set({
-      'UID': friendUID
-    });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Friend request sent!')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('User not found')),
+      );
+    }
+
+    // await userDocRef.set({
+    //   'friends': FieldValue.arrayUnion([friendUID])
+    // }, SetOptions(merge: true));
+
+    // await userDocRef.collection('friends').doc(friendUID).set({
+    //   'UID': friendUID
+    // });
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Friend added!'))

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -95,7 +95,7 @@ class _FriendsListState extends State<FriendsList>{
   if (friendDocRef.exists) { // This will be true even if the document has no fields
     DocumentReference friendsRequests = uidCollection
           .doc(friendUID)
-          .collection('friend_requests')
+          .collection('friendRequests')
           .doc(_auth.currentUser?.uid);
 
       await friendsRequests.set({
@@ -119,15 +119,6 @@ class _FriendsListState extends State<FriendsList>{
     // await userDocRef.collection('friends').doc(friendUID).set({
     //   'UID': friendUID
     // });
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Friend added!'))
-    );
-  } else {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('User not found')),
-    );
-  }
 }
 
 ///*********************************************************

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -66,7 +66,7 @@ class _FriendsListState extends State<FriendsList>{
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final TextEditingController _searchController = TextEditingController();
-
+  int _selectedIndex = 0;
 
   @override
   void initState() {
@@ -266,6 +266,34 @@ void _pokeFriend(String friendUID) async {
               },
             ),
           ),
+          BottomNavigationBar(
+          currentIndex: _selectedIndex,
+            onTap: (index) {
+              if (index == 1) { // Assuming the 'Pokes' button is at index 1
+                showModalBottomSheet(
+                  context: context,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                  ),
+                  builder: (context) => const PokeNotificationsPage(),
+                );
+              } else {
+                setState(() {
+                  _selectedIndex = index;
+                });
+              }
+            },
+            items: const [
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home),
+                label: 'Add Friends',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.waving_hand),
+                label: 'Pokes',
+              ),
+            ],
+          )
        ],
       )
     );
@@ -280,6 +308,7 @@ void _pokeFriend(String friendUID) async {
 /// them when the notifications button is pressed
 ///*********************************************************
 class PokeNotificationsPage extends StatelessWidget {
+
   const PokeNotificationsPage({super.key});
 
   @override
@@ -324,3 +353,5 @@ class PokeNotificationsPage extends StatelessWidget {
     );
   }
 }
+
+

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -161,7 +161,7 @@ void _pokeFriend(String friendUID) async {
                               onPressed: () => _pokeFriend(friendUID),
                             ),
                             IconButton(
-                              icon: const Icon(Icons.close, color: Colors.grey),
+                              icon: const Icon(Icons.close, color: Colors.red),
                               onPressed: () => _deleteFriend(friendUID),
                             ),
                           ],
@@ -190,10 +190,16 @@ void _pokeFriend(String friendUID) async {
               } else if (index == 0) { 
             showModalBottomSheet(
               context: context,
+               isScrollControlled: true,
               shape: const RoundedRectangleBorder(
                 borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
               ),
-              builder: (context) => ShowAddFriendsSheet(),
+             builder: (context) => Padding(
+    padding: EdgeInsets.only(
+      bottom: MediaQuery.of(context).viewInsets.bottom, // Adjusts for keyboard
+    ),
+    child: ShowAddFriendsSheet(),
+  ),
             );
               } else if (index == 2) { 
             showModalBottomSheet(

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -65,7 +65,6 @@ class FriendsList extends StatefulWidget {
 class _FriendsListState extends State<FriendsList>{
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  final TextEditingController _searchController = TextEditingController();
   int _selectedIndex = 0;
 
   @override
@@ -119,18 +118,6 @@ void _pokeFriend(String friendUID) async {
     return Scaffold(
       body: Column(
       children: [
-        IconButton(
-  icon: const Icon(Icons.notifications),
-  onPressed: () {
-    showModalBottomSheet(
-      context: context,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (context) => const PokeNotificationsPage(),
-    );
-  },
-),
         Padding(
           padding: const EdgeInsets.all(8),
         ),
@@ -295,7 +282,6 @@ class PokeNotificationsPage extends StatelessWidget {
   }
 }
 
-
 ///*********************************************************
 /// Name: ShowAddFriendsSheet
 /// 
@@ -405,6 +391,12 @@ class ShowAddFriendsSheet extends StatelessWidget {
   }
 }
 
+///*********************************************************
+/// Name: FriendRequestsSheet
+/// 
+/// Description: Displays a bottom sheet of all pending friend
+/// requests the user has
+///*********************************************************
 class FriendRequestsSheet extends StatelessWidget {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -122,6 +122,30 @@ class _FriendsListState extends State<FriendsList>{
 }
 
 ///*********************************************************
+/// Name: _handleFriendRequest
+/// 
+/// Description: Handles when a user accepts or denies a friend
+/// request.
+///*********************************************************
+void _handleFriendRequest(String friendUID, bool accept) async {
+    DocumentReference userDocRef = _firestore.collection('UID').doc(_auth.currentUser?.uid);
+    DocumentReference friendDocRef = _firestore.collection('UID').doc(friendUID);
+
+    if (accept) {
+      await userDocRef.update({
+        'friends': FieldValue.arrayUnion([friendUID]),
+      });
+      await friendDocRef.update({
+        'friends': FieldValue.arrayUnion([_auth.currentUser?.uid]),
+      });
+    }
+    else{
+    await userDocRef.collection('friend_requests').doc(friendUID).delete();
+  }
+  }
+
+
+///*********************************************************
 /// Name: _deleteFriend
 /// 
 /// Description: When the small X near a friend's card in the 


### PR DESCRIPTION
Overhauled the add friends paged
- Simplified user flow to three bottom buttons for adding friends, viewing pokes, and viewing friend requests
- each button pulls up a bottom sheet showing their necessary UI elements
- Added friend requests as an intermediary step to adding a friend. So now a user must accept a friend request when someone tries to add them