### PR TITLE
Proc92/app bar redesign

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,22 +85,6 @@ Future<void> initializeMain() async {
     await generateAppsList();
     await initializeAppNameColorMapping();
     await _writeScreenTimeData();
-  /*_currentToHistorical().whenComplete(() {
-    _checkSTPermission().whenComplete((){
-      _getScreenTime().whenComplete((){
-        getAvailableWeeks().whenComplete((){
-          fetchWeeklyScreenTime().whenComplete((){
-            generateAppsList().whenComplete(() {
-              initializeAppNameColorMapping().whenComplete((){
-                _writeScreenTimeData();
-                //Launches login screen first which returns ProcrasiHater app if success
-              });
-            });
-          });
-        }); 
-      });
-    });
-  });*/
  }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -162,8 +162,9 @@ class ProcrastiHater extends StatelessWidget {
           color: lightBlue,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
-        drawerTheme: DrawerThemeData(
-
+        dialogTheme: DialogThemeData(
+          backgroundColor: darkBlue,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       ),
       //Main route of the app

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,8 +52,8 @@ String? uid = auth.currentUser?.uid;
 //Reference to user's document in Firestore
 DocumentReference userRef = mainCollection.doc(uid);
 
-const Color darkBlue = Color.fromRGBO(10, 29, 55, 1);
-const Color lightBlue = Color.fromRGBO(12, 36, 68, 1);
+const Color darkBlue = Color.fromRGBO(10, 27, 46, 1);
+const Color lightBlue = Color.fromRGBO(14, 40, 77, 1);
 const Color beige = Color.fromARGB(255, 229, 214, 160);
 const Color lightBeige = Color.fromARGB(255, 208, 196, 153);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,7 +123,7 @@ class ProcrastiHater extends StatelessWidget {
         ),
         appBarTheme: AppBarTheme(
           centerTitle: true,
-          toolbarHeight: screenHeight * .05,
+          toolbarHeight: screenHeight * .06,
           backgroundColor: Color(0xFF161B22),
           foregroundColor: Color(0xFFC9D1D9),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -161,7 +161,9 @@ class ProcrastiHater extends StatelessWidget {
         cardTheme: CardThemeData(
           color: lightBlue,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          //margin: EdgeInsets.all(10.0),
+        ),
+        drawerTheme: DrawerThemeData(
+
         ),
       ),
       //Main route of the app

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,13 +181,7 @@ class ProcrastiHater extends StatelessWidget {
         // Listen to auth state changes instead of using a FutureBuilder
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snapshot) {
-          // Show loading indicator while connecting to Firebase
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            );
-          }
-
+          
           // If user is null (signed out), show login screen
           if (snapshot.data == null) {
             return const LoginScreen();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -246,7 +246,8 @@ class ProcrastiHater extends StatelessWidget {
               child: child,
             ),
           );
-        });
+        }
+      );
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -100,7 +100,42 @@ class ProcrastiHater extends StatelessWidget {
   @override
   //Main material app for app
   Widget build(BuildContext context) {
+    double? screenWidth = MediaQuery.of(context).size.width;
+    double? screenHeight = MediaQuery.of(context).size.height;
     return MaterialApp(
+      theme: ThemeData(
+        brightness: Brightness.dark,
+        scaffoldBackgroundColor:const Color(0xFF0D1117),
+        primaryColor: const Color(0xFF1F6FEB),
+        colorScheme: const ColorScheme.dark(
+          surface: Color(0xFF161B22),
+          primary: Color(0xFF1F6FEB),
+          primaryContainer: Color(0xFF388BFD),
+          secondary: Color(0xFF2E8BFF),
+          onPrimary: Color(0xFFC9D1D9),
+          onSecondary: Color(0xFFC9D1D9),
+          onSurface: Color(0xFF8B949E),
+        ),
+        textTheme: const TextTheme(
+          bodyLarge: TextStyle(color: Color(0xFFC9D1D9)),
+          bodyMedium: TextStyle(color: Color(0xFF8B949E)),
+          titleLarge: TextStyle(color: Color(0xFFC9D1D9), fontWeight: FontWeight.bold),
+        ),
+        appBarTheme: AppBarTheme(
+          toolbarHeight: screenHeight * .05,
+          backgroundColor: Color(0xFF0D1117),
+          foregroundColor: Color(0xFFC9D1D9),
+          elevation: 1,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: const Color(0xFF161B22),
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          )
+        ),
+        
+      ),
       //Main route of the app
       initialRoute: '/homePage',
       //Route generation based on what the route needs to do

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,19 +122,30 @@ class ProcrastiHater extends StatelessWidget {
           titleLarge: TextStyle(color: Color(0xFFC9D1D9), fontWeight: FontWeight.bold),
         ),
         appBarTheme: AppBarTheme(
+          centerTitle: true,
           toolbarHeight: screenHeight * .05,
-          backgroundColor: Color(0xFF0D1117),
+          backgroundColor: Color(0xFF161B22),
           foregroundColor: Color(0xFFC9D1D9),
-          elevation: 1,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFF161B22),
-            foregroundColor: Colors.white,
+            foregroundColor: Color(0xFFC9D1D9),
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           )
         ),
-        
+        dividerTheme: DividerThemeData(
+          color: Color(0xFFC9D1D9),
+          indent: 5,
+          endIndent: 5,
+          thickness: 1,
+        ),
+        cardTheme: CardThemeData(
+          color: Color(0xFF0D1117),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          margin: EdgeInsets.all(10.0),
+        ),
       ),
       //Main route of the app
       initialRoute: '/homePage',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'pages/calendar.dart';
 import 'pages/study_mode.dart';
 import 'pages/app_limits_page.dart';
 import 'apps_list.dart';
+import 'pages/graph/colors.dart';
 
 //Global Variables
 //Native Kotlin method channel
@@ -50,6 +51,11 @@ final CollectionReference mainCollection = firestore.collection('UID');
 String? uid = auth.currentUser?.uid;
 //Reference to user's document in Firestore
 DocumentReference userRef = mainCollection.doc(uid);
+
+const Color darkBlue = Color.fromRGBO(10, 29, 55, 1);
+const Color lightBlue = Color.fromRGBO(12, 36, 68, 1);
+const Color beige = Color.fromARGB(255, 229, 214, 160);
+const Color lightBeige = Color.fromARGB(255, 208, 196, 153);
 
 ///*********************************
 /// Name: main
@@ -104,35 +110,46 @@ class ProcrastiHater extends StatelessWidget {
     double? screenHeight = MediaQuery.of(context).size.height;
     return MaterialApp(
       theme: ThemeData(
-        brightness: Brightness.dark,
-        scaffoldBackgroundColor:const Color(0xFF0D1117),
-        primaryColor: const Color(0xFF1F6FEB),
+        //brightness: Brightness.dark,
+        scaffoldBackgroundColor: darkBlue,
+        //canvasColor: beige,
         colorScheme: const ColorScheme.dark(
-          surface: Color(0xFF161B22),
-          primary: Color(0xFF1F6FEB),
-          primaryContainer: Color(0xFF388BFD),
-          secondary: Color(0xFF2E8BFF),
-          onPrimary: Color(0xFFC9D1D9),
-          onSecondary: Color(0xFFC9D1D9),
-          onSurface: Color(0xFF8B949E),
+          brightness: Brightness.dark,
+          primary: beige,
+          onPrimary: lightBlue,
+          primaryContainer: beige,
+          surface: lightBlue,
+          onSurface: beige,
+          outline: lightBeige,
         ),
         textTheme: const TextTheme(
-          bodyLarge: TextStyle(color: Color(0xFFC9D1D9)),
-          bodyMedium: TextStyle(color: Color(0xFF8B949E)),
-          titleLarge: TextStyle(color: Color(0xFFC9D1D9), fontWeight: FontWeight.bold),
+          displayLarge: TextStyle(color: beige),
+          displayMedium: TextStyle(color: beige),
+          displaySmall: TextStyle(color: beige),
+          headlineLarge: TextStyle(color: beige),
+          headlineMedium: TextStyle(color: beige),
+          headlineSmall: TextStyle(color: beige),
+          titleLarge: TextStyle(color: beige),
+          titleMedium: TextStyle(color: beige),
+          titleSmall: TextStyle(color: lightBeige),
+          bodyLarge: TextStyle(color: lightBeige),
+          bodyMedium: TextStyle(color: lightBeige),
+          bodySmall: TextStyle(color: lightBeige),
+          labelLarge: TextStyle(color: lightBeige),
+          labelMedium: TextStyle(color: lightBeige),
+          labelSmall: TextStyle(color: lightBeige),
         ),
         appBarTheme: AppBarTheme(
           centerTitle: true,
           toolbarHeight: screenHeight * .06,
-          backgroundColor: Color(0xFF161B22),
-          foregroundColor: Color(0xFFC9D1D9),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: lightBlue,
+          foregroundColor: beige,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF161B22),
-            foregroundColor: Color(0xFFC9D1D9),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            backgroundColor: lightBlue,
+            foregroundColor: beige,
           )
         ),
         dividerTheme: DividerThemeData(
@@ -142,9 +159,9 @@ class ProcrastiHater extends StatelessWidget {
           thickness: 1,
         ),
         cardTheme: CardThemeData(
-          color: Color(0xFF0D1117),
+          color: lightBlue,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          margin: EdgeInsets.all(10.0),
+          //margin: EdgeInsets.all(10.0),
         ),
       ),
       //Main route of the app

--- a/lib/pages/app_limits_page.dart
+++ b/lib/pages/app_limits_page.dart
@@ -65,7 +65,7 @@ class _AppLimitsPageState extends State<AppLimitsPage>{
         itemBuilder: (context, index) {
           return ListTile(
             contentPadding: EdgeInsets.only(bottom: 5, left: 10, right: 10),
-            tileColor: Colors.indigo.shade100,
+            //: Colors.indigo.shade100,
             title: Text(
               appNames[index],
               style: TextStyle(

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -235,7 +235,7 @@ void _pokeFriend(String friendUID) async {
                                     title: Text("Delete Friend"),
                                     content: Text("Are you sure you want to delete $displayName from your friends list?"),
                                     actions: [
-                                      TextButton(
+                                      ElevatedButton(
                                         onPressed: (){
                                           _deleteFriend(friendUID); //Actually deletes friend
                                           Navigator.pop(alertContext, "Yes");

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -116,7 +116,7 @@ void _pokeFriend(String friendUID) async {
   Widget build(BuildContext context) {
     return Scaffold(
        appBar: AppBar(
-        title: Text("ProcrastiStats"),
+        title: Text("ProcrastiFriends"),
         actions: [
           // Creating little user icon you can press to view account info
           IconButton(

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -16,6 +16,9 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
+//Page Imports 
+import '/main.dart';
+
 ///*********************************
 /// Name: HistoricalDataPage
 /// 
@@ -38,10 +41,6 @@ class FriendsPage extends StatelessWidget {
         }
       },
       child: Scaffold(
-        appBar: AppBar(
-          automaticallyImplyLeading: false,
-          title: const Text("ProcrastiFriends"),
-        ),
         body: FriendsList(),
       ),
     );
@@ -116,6 +115,74 @@ void _pokeFriend(String friendUID) async {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+       appBar: AppBar(
+        title: Text("ProcrastiStats"),
+        actions: [
+          // Creating little user icon you can press to view account info
+          IconButton(
+            icon: CircleAvatar(
+              backgroundImage: NetworkImage(
+                // Use user's pfp as icon image if there is no pfp use this link as a default
+                auth.currentUser?.photoURL ?? 'https://picsum.photos/id/237/200/300',
+              ),
+            ),
+            onPressed: () async {
+              await Navigator.pushNamed(context, "/profileSettings");
+              // Reload the user in case anything changed
+              await auth.currentUser?.reload();
+              // Reload UI in case things changed
+              setState(() {});
+            },
+          )
+        ],
+      ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            SizedBox(
+              height: 80,
+              child:  DrawerHeader(
+              decoration: BoxDecoration(
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12.0),
+                    child: Image.asset("assets/logo.jpg"),
+                  ),
+                  Text("ProcrastiTools",),
+              ],
+              )
+              ),
+            ),
+              ListTile(
+              trailing: Icon(Icons.calendar_today),
+              title: Text("Calendar"),
+              onTap:() {
+                Navigator.pushNamed(context, '/calendarPage');
+              },
+            ),
+           // const Divider(),
+             ListTile(
+              trailing: Icon(Icons.school),
+              title: Text("Study Mode"),
+              onTap: () {
+                Navigator.pushNamed(context, '/studyModePage');
+              },
+            ),
+            //const Divider(),
+            ListTile(
+              trailing: Icon(Icons.alarm),
+              title: Text("App Limits"),
+              onTap: () {
+                Navigator.pushNamed(context, '/appLimitsPage');
+              },
+            )
+          ],
+        ),
+      ),
       body: Column(
       children: [
         Padding(

--- a/lib/pages/friend_page.dart
+++ b/lib/pages/friend_page.dart
@@ -218,7 +218,7 @@ void _pokeFriend(String friendUID) async {
                           title: Text(displayName),
                           subtitle: Text(
                             'Daily Hours: ${totalDailyHours.toStringAsFixed(2)}',
-                            style: TextStyle(color: Colors.grey), 
+                            //style: TextStyle(color: Colors.grey), 
                           ),
                           trailing: Row(
                           mainAxisSize: MainAxisSize.min,
@@ -243,8 +243,8 @@ void _pokeFriend(String friendUID) async {
           ),
           BottomNavigationBar(
           currentIndex: _selectedIndex,
-          selectedItemColor: Colors.grey[700],  
-          unselectedItemColor: Colors.grey[700],
+          selectedItemColor: beige,  
+          unselectedItemColor: beige,
             onTap: (index) {
               if (index == 1) { // Assuming the 'Pokes' button is at index 1
                 showModalBottomSheet(

--- a/lib/pages/graph/fetch_data.dart
+++ b/lib/pages/graph/fetch_data.dart
@@ -113,18 +113,18 @@ Future<void> fetchWeeklyScreenTime() async {
 }
 
 Future<double> fetchTotalDayScreentime() async {
-   //Update the reference to the user doc before accessing
-  updateUserRef();
-  //Variable for scoping into the users appUsageHistory collection
-  final current = await userRef.get();
-  double totalDaily = current['totalDailyHours'];  
-  return totalDaily;
+  final dailyScreenTime = (await FirebaseFirestore.instance
+    .collection('UID')
+    .doc(userRef.id)
+    .get())
+    .get('totalDailyHours') as double;
+    return dailyScreenTime;
 }
 Future<int> fetchPoints() async {
-   //Update the reference to the user doc before accessing
-  updateUserRef();
-  //Variable for scoping into the users appUsageHistory collection
-  final current = await userRef.get();
-  int points = current['points'];  
-  return points;
+  final points = (await FirebaseFirestore.instance
+    .collection('UID')
+    .doc(userRef.id)
+    .get())
+    .get('points') as int;
+    return points;
 }

--- a/lib/pages/graph/fetch_data.dart
+++ b/lib/pages/graph/fetch_data.dart
@@ -111,3 +111,20 @@ Future<void> fetchWeeklyScreenTime() async {
       ..sort((a, b) => dayOrder.indexOf(a.key).compareTo(dayOrder.indexOf(b.key))),
   );
 }
+
+Future<double> fetchTotalDayScreentime() async {
+   //Update the reference to the user doc before accessing
+  updateUserRef();
+  //Variable for scoping into the users appUsageHistory collection
+  final current = await userRef.get();
+  double totalDaily = current['totalDailyHours'];  
+  return totalDaily;
+}
+Future<int> fetchPoints() async {
+   //Update the reference to the user doc before accessing
+  updateUserRef();
+  //Variable for scoping into the users appUsageHistory collection
+  final current = await userRef.get();
+  int points = current['points'];  
+  return points;
+}

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -151,7 +151,7 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
       return Center(child: CircularProgressIndicator());
     }
     return Padding(
-      padding: const EdgeInsets.all(10.0),
+      padding: const EdgeInsets.all(4.0),
       child: Column(
         children: [
           CustomDropdown.multiSelectSearch(
@@ -161,6 +161,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                     searchFieldDecoration: SearchFieldDecoration(
                       textStyle: TextStyle(color: lightBeige),
                       fillColor: darkBlue,
+                    ),
+                    listItemDecoration: ListItemDecoration(
+                      highlightColor: darkBlue,
+                      selectedColor: darkBlue,
                     ),
                   ),
             closedHeaderPadding: EdgeInsets.all(8.0),
@@ -192,6 +196,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                   decoration: CustomDropdownDecoration(
                     closedFillColor: lightBlue,
                     expandedFillColor: lightBlue,
+                      listItemDecoration: ListItemDecoration(
+                      highlightColor: darkBlue,
+                      selectedColor: darkBlue,
+                    )
                   ),
                   items: categories, 
                   overlayHeight: 525,
@@ -221,6 +229,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                   decoration: CustomDropdownDecoration(
                     closedFillColor: lightBlue,
                     expandedFillColor: lightBlue,
+                    listItemDecoration: ListItemDecoration(
+                      highlightColor: darkBlue,
+                      selectedColor: darkBlue,
+                    ),
                   ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
@@ -247,11 +259,14 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
             ],
           ),
           //Graph Title
-          Text("Weekly Graph", style: TextStyle(fontSize: 18),),
+          Text("Historical Phone Usage", style: TextStyle(fontSize: 18),),
           Expanded(
             child: BarChart(
               BarChartData(
-                alignment: BarChartAlignment.center,
+                maxY: tallestDayBar(weekData) + 1,
+                groupsSpace: 60,
+                alignment: BarChartAlignment.spaceAround,
+                backgroundColor: lightBlue,
                 //Title Widgets
                 titlesData: FlTitlesData(
                   leftTitles: AxisTitles(
@@ -259,7 +274,7 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                       maxIncluded: false,
                       showTitles: true,
                       interval: 1,
-                      reservedSize: 25,
+                      reservedSize: 20,
                       getTitlesWidget: sideTitles,
                     )
                   ),
@@ -282,10 +297,15 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                   ),
                 ),
                 //Style Widgets
-                borderData: FlBorderData(show: true),
+                borderData: FlBorderData(
+                  border: Border.all(
+                    color: beige,
+                    width: 2,
+                  ),
+                  show: true
+                ),
                 gridData: FlGridData(
-                  drawVerticalLine: false,
-                  show: true,
+                  show: false,
                 ),
                 //Functionality Widgets
                 barTouchData: loadTouch(weekData),
@@ -295,7 +315,7 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
           ),
           Row(
             //Equal spacing between children
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [
               //Previous arrow button
               IconButton(
@@ -372,6 +392,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   List<String> selectedCategories = [];
   Map<String, Map<String, String>> dailyData = {};
   String? selectedFilter = "";
+  double totalDaily = 0;
+  int points = 0;
 
   @override
   //Initialize colors making sure all apps are mapped to a color before displaying
@@ -382,6 +404,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   }
 
   Future<void> _initializeData() async {
+    totalDaily = await fetchTotalDayScreentime();
+    points = await fetchPoints();
     setState(() {
       availableApps = screenTimeData.keys.toList();
     });
@@ -434,16 +458,19 @@ class _DailyGraphViewState extends State<DailyGraphView> {
     return Padding(
       padding: const EdgeInsets.all(10.0),
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Expanded(
                 child: CustomDropdown.multiSelect(
                   decoration: CustomDropdownDecoration(
                     closedFillColor: lightBlue,
                     expandedFillColor: lightBlue,
-
+                    listItemDecoration: ListItemDecoration(
+                      highlightColor: darkBlue,
+                      selectedColor: darkBlue,
+                    ),
                   ),
                   items: categories, 
                   overlayHeight: 525,
@@ -483,6 +510,10 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                    decoration: CustomDropdownDecoration(
                     closedFillColor: lightBlue,
                     expandedFillColor: lightBlue,
+                    listItemDecoration: ListItemDecoration(
+                      highlightColor: darkBlue,
+                      selectedColor: darkBlue,
+                    ),
                   ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
@@ -509,7 +540,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
             ],
           ),
           //Title for graph
-          Text("Daily Graph", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),),
+          Text("Current Phone Usage", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),),
           Expanded(
             //Widget to allow scrolling of graph if it overflows the screen
             child: SingleChildScrollView(
@@ -522,7 +553,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                   width: 100 + availableApps.length * 70,
                   child: BarChart(
                     BarChartData(
-                      maxY: tallestBar(dailyData) + 1,
+                      maxY: tallestAppBar(dailyData) + 1,
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
                       backgroundColor: lightBlue,
@@ -551,7 +582,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                           sideTitles: SideTitles(
                             showTitles: true,
                             getTitlesWidget: bottomAppTitles,
-                            reservedSize: 60,
+                            reservedSize: 25,
                           )
                         ),
                       ),
@@ -564,9 +595,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                         show: true
                         ),
                       gridData: FlGridData(
-                        drawHorizontalLine: false,
-                        drawVerticalLine: false,
-                        show: true,
+                        show: false,
                       ),
                       //Functionality Widgets
                       barTouchData: loadTouch(dailyData),
@@ -577,6 +606,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
               )
             ),
           ),
+          Text("Today's Procrastination Total:",),
+          Text("Hours: $totalDaily | Points: $points"),
         ],
       )
     );

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -267,7 +267,7 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
               width: screenWidth - (screenWidth * 0.05),
               child: BarChart(
               BarChartData(
-                maxY: tallestDayBar(weekData).ceilToDouble(),
+                maxY: tallestDayBar(weekData),
                 groupsSpace: 60,
                 alignment: BarChartAlignment.spaceAround,
                 backgroundColor: lightBlue,
@@ -462,7 +462,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
     double? screenWidth = MediaQuery.of(context).size.width;
     double? screenHeight = MediaQuery.of(context).size.height;
     return Padding(
-      padding: const EdgeInsets.all(10.0),
+      padding: const EdgeInsets.all(4.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -559,7 +559,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                   width: 100 + availableApps.length * 70,
                   child: BarChart(
                     BarChartData(
-                      maxY: tallestAppBar(dailyData).ceilToDouble(),
+                      maxY: tallestAppBar(dailyData),
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
                       backgroundColor: lightBlue,

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -404,8 +404,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   //Initialize colors making sure all apps are mapped to a color before displaying
   void initState() {
     super.initState();
-    dailyData = screenTimeData;
     _initializeData();
+    dailyData = screenTimeData;
   }
 
   Future<void> _initializeData() async {
@@ -461,6 +461,9 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   Widget build(BuildContext context) {
     double? screenWidth = MediaQuery.of(context).size.width;
     double? screenHeight = MediaQuery.of(context).size.height;
+    if (dailyData.isEmpty) {
+      return Center(child: CircularProgressIndicator());
+    }
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: Column(

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -426,10 +426,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   }
   @override
   Widget build(BuildContext context) {
-    //Display loading screen if data is not present
-    /*if (screenTimeData.isEmpty) {
-      return Center(child: Text("No data recorded"));
-    }*/
+    double? screenWidth = MediaQuery.of(context).size.width;
+    double? screenHeight = MediaQuery.of(context).size.height;
     return Padding(
       padding: const EdgeInsets.all(10.0),
       child: Column(
@@ -508,21 +506,22 @@ class _DailyGraphViewState extends State<DailyGraphView> {
             ],
           ),
           //Title for graph
-          Text("Daily Graph", style: TextStyle(fontSize: 18),),
+          Text("Daily Graph", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),),
           Expanded(
             //Widget to allow scrolling of graph if it overflows the screen
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: ConstrainedBox(
                 //Sets a minimum size for graph
-                constraints: BoxConstraints(minWidth: 390),
+                constraints: BoxConstraints(minWidth: screenWidth - (screenWidth * 0.075)),
                 child: SizedBox(
                   //Dynamically size graph based on amount of apps
                   width: 100 + availableApps.length * 70,
                   child: BarChart(
                     BarChartData(
                       groupsSpace: 60,
-                      alignment: BarChartAlignment.center,
+                      alignment: BarChartAlignment.spaceAround,
+                      backgroundColor: Color(0xFF161B22),
                       //Title Widgets
                       titlesData: FlTitlesData(
                         leftTitles: AxisTitles(
@@ -553,8 +552,15 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                         ),
                       ),
                       //Style Widgets
-                      borderData: FlBorderData(show: true),
+                      borderData: FlBorderData(
+                        border: Border.all(
+                          color: Color(0xFF1F6FEB),
+                          width: 2,
+                        ),
+                        show: true
+                        ),
                       gridData: FlGridData(
+                        drawHorizontalLine: false,
                         drawVerticalLine: false,
                         show: true,
                       ),

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -156,6 +156,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
         children: [
           const SizedBox(height: 60),
           CustomDropdown.multiSelectSearch(
+            decoration: CustomDropdownDecoration(
+                    closedFillColor: Color(0xFF161B22),
+                    expandedFillColor: Color(0xFF161B22),
+                  ),
             closedHeaderPadding: EdgeInsets.all(8.0),
             expandedHeaderPadding: EdgeInsets.all(8.0),
             items: appNameToColor.keys.toList(), 
@@ -182,6 +186,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
             children: [
               Expanded(
                 child: CustomDropdown.multiSelect(
+                  decoration: CustomDropdownDecoration(
+                    closedFillColor: Color(0xFF161B22),
+                    expandedFillColor: Color(0xFF161B22),
+                  ),
                   items: categories, 
                   overlayHeight: 525,
                   closedHeaderPadding: EdgeInsets.all(8.0),
@@ -207,6 +215,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
               ),
               Expanded(
                 child: CustomDropdown(
+                  decoration: CustomDropdownDecoration(
+                    closedFillColor: Color(0xFF161B22),
+                    expandedFillColor: Color(0xFF161B22),
+                  ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
                   items: filters, 
@@ -267,7 +279,6 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                   ),
                 ),
                 //Style Widgets
-                backgroundColor: Colors.white,
                 borderData: FlBorderData(show: true),
                 gridData: FlGridData(
                   drawVerticalLine: false,
@@ -429,6 +440,10 @@ class _DailyGraphViewState extends State<DailyGraphView> {
             children: [
               Expanded(
                 child: CustomDropdown.multiSelect(
+                  decoration: CustomDropdownDecoration(
+                    closedFillColor: Color(0xFF161B22),
+                    expandedFillColor: Color(0xFF161B22),
+                  ),
                   items: categories, 
                   overlayHeight: 525,
                   closedHeaderPadding: EdgeInsets.all(8.0),
@@ -464,6 +479,10 @@ class _DailyGraphViewState extends State<DailyGraphView> {
               ),
               Expanded(
                 child: CustomDropdown(
+                   decoration: CustomDropdownDecoration(
+                    closedFillColor: Color(0xFF161B22),
+                    expandedFillColor: Color(0xFF161B22),
+                  ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
                   items: filters, 
@@ -534,7 +553,6 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                         ),
                       ),
                       //Style Widgets
-                      backgroundColor: Colors.white,
                       borderData: FlBorderData(show: true),
                       gridData: FlGridData(
                         drawVerticalLine: false,

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -154,11 +154,14 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
       padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
-          const SizedBox(height: 60),
           CustomDropdown.multiSelectSearch(
             decoration: CustomDropdownDecoration(
-                    closedFillColor: Color(0xFF161B22),
-                    expandedFillColor: Color(0xFF161B22),
+                    closedFillColor: lightBlue,
+                    expandedFillColor: lightBlue,
+                    searchFieldDecoration: SearchFieldDecoration(
+                      textStyle: TextStyle(color: lightBeige),
+                      fillColor: darkBlue,
+                    ),
                   ),
             closedHeaderPadding: EdgeInsets.all(8.0),
             expandedHeaderPadding: EdgeInsets.all(8.0),
@@ -187,8 +190,8 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
               Expanded(
                 child: CustomDropdown.multiSelect(
                   decoration: CustomDropdownDecoration(
-                    closedFillColor: Color(0xFF161B22),
-                    expandedFillColor: Color(0xFF161B22),
+                    closedFillColor: lightBlue,
+                    expandedFillColor: lightBlue,
                   ),
                   items: categories, 
                   overlayHeight: 525,
@@ -216,8 +219,8 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
               Expanded(
                 child: CustomDropdown(
                   decoration: CustomDropdownDecoration(
-                    closedFillColor: Color(0xFF161B22),
-                    expandedFillColor: Color(0xFF161B22),
+                    closedFillColor: lightBlue,
+                    expandedFillColor: lightBlue,
                   ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
@@ -438,8 +441,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
               Expanded(
                 child: CustomDropdown.multiSelect(
                   decoration: CustomDropdownDecoration(
-                    closedFillColor: Color(0xFF161B22),
-                    expandedFillColor: Color(0xFF161B22),
+                    closedFillColor: lightBlue,
+                    expandedFillColor: lightBlue,
                   ),
                   items: categories, 
                   overlayHeight: 525,
@@ -477,8 +480,8 @@ class _DailyGraphViewState extends State<DailyGraphView> {
               Expanded(
                 child: CustomDropdown(
                    decoration: CustomDropdownDecoration(
-                    closedFillColor: Color(0xFF161B22),
-                    expandedFillColor: Color(0xFF161B22),
+                    closedFillColor: lightBlue,
+                    expandedFillColor: lightBlue,
                   ),
                   closedHeaderPadding: EdgeInsets.all(8.0),
                   expandedHeaderPadding: EdgeInsets.all(8.0),
@@ -521,7 +524,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                       maxY: tallestBar(dailyData) + 1,
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
-                      backgroundColor: Color(0xFF161B22),
+                      //backgroundColor: Color(0xFF161B22),
                       //Title Widgets
                       titlesData: FlTitlesData(
                         leftTitles: AxisTitles(
@@ -554,7 +557,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                       //Style Widgets
                       borderData: FlBorderData(
                         border: Border.all(
-                          color: Color(0xFF1F6FEB),
+                          //color: Color(0xFF1F6FEB),
                           width: 2,
                         ),
                         show: true

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -147,6 +147,8 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
 
   @override
   Widget build(BuildContext context) {
+    double? screenWidth = MediaQuery.of(context).size.width;
+    double? screenHeight = MediaQuery.of(context).size.height;
     if (weekData.isEmpty) {
       return Center(child: CircularProgressIndicator());
     }
@@ -261,9 +263,11 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
           //Graph Title
           Text("Historical Phone Usage", style: TextStyle(fontSize: 18),),
           Expanded(
-            child: BarChart(
+            child: SizedBox(
+              width: screenWidth - (screenWidth * 0.05),
+              child: BarChart(
               BarChartData(
-                maxY: tallestDayBar(weekData) + 1,
+                maxY: tallestDayBar(weekData).ceilToDouble(),
                 groupsSpace: 60,
                 alignment: BarChartAlignment.spaceAround,
                 backgroundColor: lightBlue,
@@ -271,7 +275,7 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                 titlesData: FlTitlesData(
                   leftTitles: AxisTitles(
                     sideTitles: SideTitles(
-                      maxIncluded: false,
+                      maxIncluded: true,
                       showTitles: true,
                       interval: 1,
                       reservedSize: 20,
@@ -280,10 +284,10 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                   ),
                   rightTitles: AxisTitles(
                     sideTitles: SideTitles(
-                      maxIncluded: false,
+                      maxIncluded: true,
                       showTitles: true,
                       interval: 1,
-                      reservedSize: 25,
+                      reservedSize: 20,
                       getTitlesWidget: sideTitles,
                     )
                   ),
@@ -311,7 +315,8 @@ class _WeeklyGraphViewState extends State<WeeklyGraphView> {
                 barTouchData: loadTouch(weekData),
                 barGroups: generateWeeklyChart(weekData),
               )
-            )
+            ),
+            ),
           ),
           Row(
             //Equal spacing between children
@@ -406,6 +411,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
   Future<void> _initializeData() async {
     totalDaily = await fetchTotalDayScreentime();
     points = await fetchPoints();
+    if (!mounted) return;
     setState(() {
       availableApps = screenTimeData.keys.toList();
     });
@@ -540,20 +546,20 @@ class _DailyGraphViewState extends State<DailyGraphView> {
             ],
           ),
           //Title for graph
-          Text("Current Phone Usage", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),),
+          Text("Current Phone Usage", style: TextStyle(fontSize: 18),),
           Expanded(
             //Widget to allow scrolling of graph if it overflows the screen
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: ConstrainedBox(
                 //Sets a minimum size for graph
-                constraints: BoxConstraints(minWidth: screenWidth - (screenWidth * 0.075)),
+                constraints: BoxConstraints(minWidth: screenWidth - (screenWidth * 0.05)),
                 child: SizedBox(
                   //Dynamically size graph based on amount of apps
                   width: 100 + availableApps.length * 70,
                   child: BarChart(
                     BarChartData(
-                      maxY: tallestAppBar(dailyData) + 1,
+                      maxY: tallestAppBar(dailyData).ceilToDouble(),
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
                       backgroundColor: lightBlue,
@@ -561,19 +567,19 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                       titlesData: FlTitlesData(
                         leftTitles: AxisTitles(
                           sideTitles: SideTitles(
-                            maxIncluded: false,
+                            maxIncluded: true,
                             showTitles: true,
                             interval: 1,
-                            reservedSize: 25,
+                            reservedSize: 20,
                             getTitlesWidget: sideTitles,
                           )
                         ),
                         rightTitles: AxisTitles(
                           sideTitles: SideTitles(
-                            maxIncluded: false,
+                            maxIncluded: true,
                             showTitles: true,
                             interval: 1,
-                            reservedSize: 25,
+                            reservedSize: 20,
                             getTitlesWidget: sideTitles,
                           )
                         ),

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -443,6 +443,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                   decoration: CustomDropdownDecoration(
                     closedFillColor: lightBlue,
                     expandedFillColor: lightBlue,
+
                   ),
                   items: categories, 
                   overlayHeight: 525,
@@ -524,7 +525,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                       maxY: tallestBar(dailyData) + 1,
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
-                      //backgroundColor: Color(0xFF161B22),
+                      backgroundColor: lightBlue,
                       //Title Widgets
                       titlesData: FlTitlesData(
                         leftTitles: AxisTitles(
@@ -557,7 +558,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                       //Style Widgets
                       borderData: FlBorderData(
                         border: Border.all(
-                          //color: Color(0xFF1F6FEB),
+                          color: beige,
                           width: 2,
                         ),
                         show: true

--- a/lib/pages/graph/graph.dart
+++ b/lib/pages/graph/graph.dart
@@ -432,7 +432,6 @@ class _DailyGraphViewState extends State<DailyGraphView> {
       padding: const EdgeInsets.all(10.0),
       child: Column(
         children: [
-          const SizedBox(height: 60),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -519,6 +518,7 @@ class _DailyGraphViewState extends State<DailyGraphView> {
                   width: 100 + availableApps.length * 70,
                   child: BarChart(
                     BarChartData(
+                      maxY: tallestBar(dailyData) + 1,
                       groupsSpace: 60,
                       alignment: BarChartAlignment.spaceAround,
                       backgroundColor: Color(0xFF161B22),

--- a/lib/pages/graph/list_view.dart
+++ b/lib/pages/graph/list_view.dart
@@ -42,13 +42,19 @@ class ExpandedListView extends StatefulWidget {
 /// for ExpandedListView
 ///*********************************
 class _ExpandedListViewState extends State<ExpandedListView> { 
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     switch(widget.graphIndex) {
       //Daily list view
       case 0:
       //Return loading icon if no data is present
-        if (screenTimeData.isEmpty) {
+        if (widget.dayFilteredData.isEmpty) {
           return Center(child: CircularProgressIndicator());
         } 
         //Data to be displayed 

--- a/lib/pages/graph/list_view.dart
+++ b/lib/pages/graph/list_view.dart
@@ -64,14 +64,11 @@ class _ExpandedListViewState extends State<ExpandedListView> {
           itemBuilder: (context, index) {
             //Display title if first tile
             if (index == 0) {
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Center(
+              return Center(
                   child: Text(
-                    "Daily Data", 
+                    "Daily Hours", 
                     style: TextStyle(fontSize: 22),
                   )
-                ),
               );
             }
             //Build data tile
@@ -135,15 +132,14 @@ class _ExpandedListViewState extends State<ExpandedListView> {
           //Builds from the top of parent widget
           padding: EdgeInsets.zero,
           //Data tiles plus 1 for title
-          
           itemCount: dayData.length + 1,
           //Data tile builder  
           itemBuilder: (context, index) {
             //Display title if first tile
             if (index == 0) {
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Center(child: Text("${DateFormat('MM-dd-yyyy').format(currentDataset)}: ${widget.selectedBar}", style: TextStyle(fontSize: 22),)),
+              return Center(
+                child: Text(/*"${DateFormat('MM-dd-yyyy').format(currentDataset)}:*/"${widget.selectedBar} Hours", 
+                style: TextStyle(fontSize: 22),),
               );
             }
             //Build data tile
@@ -167,10 +163,6 @@ class _ExpandedListViewState extends State<ExpandedListView> {
             }
           },
         );
-      //Monthly list view
-      case 2:
-        return Center(child: Text("Monthly Graph Display"),);
-        //Center(child: CircularProgressIndicator());
       default: 
         return Center(child: CircularProgressIndicator());
     }

--- a/lib/pages/graph/list_view.dart
+++ b/lib/pages/graph/list_view.dart
@@ -103,7 +103,6 @@ class _ExpandedListViewState extends State<ExpandedListView> {
               "Select a bar to expand",
               style: const TextStyle(
                 decoration: TextDecoration.none,
-                color: Colors.black,
                 fontWeight: FontWeight.bold,
                 fontSize: 20,
               )
@@ -121,7 +120,6 @@ class _ExpandedListViewState extends State<ExpandedListView> {
               "No data available for ${widget.selectedBar}",
               style: const TextStyle(
                 decoration: TextDecoration.none,
-                color: Colors.black,
                 fontWeight: FontWeight.bold,
                 fontSize: 20,
               )

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -41,7 +41,6 @@ List<BarChartGroupData> generateWeeklyChart(Map<String, Map<String, Map<String, 
       generatedWeeklyGroupData(i, data[availableDays[i]]!)
   ]; 
 }
- 
 
 double tallestDayBar(Map<String, Map<String, Map<String, dynamic>>> data) {
   double tallestHeight = 0;
@@ -55,8 +54,15 @@ double tallestDayBar(Map<String, Map<String, Map<String, dynamic>>> data) {
       tallestHeight = dayHeight;
     }
   }
+  if (tallestHeight - tallestHeight.floor() > .5  || tallestHeight - tallestHeight.floor() == 0){
+    tallestHeight = (tallestHeight + 1).ceilToDouble();
+  }
+  else{
+    tallestHeight = tallestHeight.ceilToDouble();
+  }
   return tallestHeight;
 }
+
 
 ///*********************************
 /// Name: generatedWeeklyGroupData
@@ -121,6 +127,12 @@ double tallestAppBar(Map<String, Map<String, dynamic>> data) {
     {
       tallestHeight = double.parse(appData['hours'] ?? 0.0);
     }
+  }
+    if (tallestHeight - tallestHeight.floor() > .5  || tallestHeight - tallestHeight.floor() == 0){
+    tallestHeight = (tallestHeight + 1).ceilToDouble();
+  }
+  else{
+    tallestHeight = tallestHeight.ceilToDouble();
   }
   return tallestHeight;
 }

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -94,6 +94,18 @@ List<BarChartGroupData> generateDailyChart(Map<String, Map<String, dynamic>> dat
   ]; 
 }
 
+double tallestBar(Map<String, Map<String, dynamic>> data) {
+  double tallestHeight = 0;
+  for (int i = 0; i < data.length; i++) {
+    Map<String, dynamic> appData = data[data.keys.toList()[i]]!;
+    if (double.parse(appData['hours'] ?? 0.0) > tallestHeight)
+    {
+      tallestHeight = double.parse(appData['hours'] ?? 0.0);
+    }
+  }
+  return tallestHeight;
+}
+
 ///*********************************
 /// Name: generatedDayData
 /// 
@@ -135,13 +147,12 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
       fitInsideVertically: true,
       getTooltipColor: (group) => Colors.transparent,
       tooltipPadding: EdgeInsets.zero,
-      tooltipMargin: 0,
+      tooltipMargin: -10,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
         double totalHours = rod.toY;
         return BarTooltipItem(
           "$totalHours\n",
           const TextStyle(
-            decoration: TextDecoration.none,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
@@ -257,6 +268,6 @@ Widget bottomDayTitles(double value, TitleMeta meta) {
 ///*********************************
 Widget sideTitles(double value, TitleMeta meta) {
   return Text(
-    value.toStringAsFixed(0),
+    ' ${value.toStringAsFixed(0)}',
   );
 }

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -192,6 +192,15 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
 BarTouchData getBarWeekTouch(Map<String, Map<String, Map<String, dynamic>>> data, void Function(String) onDaySelected) {
 return BarTouchData(
     enabled: true,
+    touchExtraThreshold: const EdgeInsets.only(top: 300),
+    //Reads touch and updates the selectedDay to load list view
+    touchCallback: (event, response){
+      if (response != null && response.spot != null) {
+        int dayIndex = response.spot!.touchedBarGroupIndex;
+        String day = availableDays[dayIndex];
+        onDaySelected(day);
+      }
+    },
     //Loads app data on touch of specific bar
     touchTooltipData: BarTouchTooltipData(
       fitInsideHorizontally: true,

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -104,13 +104,16 @@ BarChartGroupData generatedDayData(int index, String appName,Map<String, dynamic
   //Return individual bars with data
   return BarChartGroupData(
     x: index,
+    showingTooltipIndicators: [0],
     barRods: [
       BarChartRodData(
         fromY: 0,
         toY: double.parse(appData['hours'] ?? 0.0),
-        width: 15, 
+        width: 35, 
         color: appNameToColor[appName],
-        borderRadius: BorderRadius.circular(5),
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(8.0), 
+          topRight: Radius.circular(8.0)),
       ),
     ],
   );
@@ -128,35 +131,20 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
     enabled: true,
     //Loads app data on touch of specific bar
     touchTooltipData: BarTouchTooltipData(
-      fitInsideVertically: true,
       fitInsideHorizontally: true,
-      tooltipPadding: const EdgeInsets.all(8.0),
-      tooltipMargin: 8.0,
+      fitInsideVertically: true,
+      getTooltipColor: (group) => Colors.transparent,
+      tooltipPadding: EdgeInsets.zero,
+      tooltipMargin: 0,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
         double totalHours = rod.toY;
-        String appName = availableApps[groupIndex];
-        String? category = data[appName]?['category'];
         return BarTooltipItem(
-          "$appName\n",
+          "$totalHours\n",
           const TextStyle(
             decoration: TextDecoration.none,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
-          children: [
-            TextSpan(
-            text: 'Hours: $totalHours\n',
-            style: const TextStyle(
-              decoration: TextDecoration.none,
-              ),
-            ),
-            TextSpan(
-            text: 'Category: $category',
-            style: const TextStyle(
-              decoration: TextDecoration.none,
-              ),
-            ),
-          ],
         );
       },
     )
@@ -269,10 +257,6 @@ Widget bottomDayTitles(double value, TitleMeta meta) {
 ///*********************************
 Widget sideTitles(double value, TitleMeta meta) {
   return Text(
-    value.toStringAsFixed(1),
-    style: const TextStyle(
-      decoration: TextDecoration.none,
-      fontSize: 10,
-    ),
+    value.toStringAsFixed(0),
   );
 }

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -130,7 +130,6 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
     touchTooltipData: BarTouchTooltipData(
       fitInsideVertically: true,
       fitInsideHorizontally: true,
-      getTooltipColor: (_) => Colors.blueGrey,
       tooltipPadding: const EdgeInsets.all(8.0),
       tooltipMargin: 8.0,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -141,7 +140,6 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
           "$appName\n",
           const TextStyle(
             decoration: TextDecoration.none,
-            color: Colors.white,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
@@ -150,14 +148,12 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
             text: 'Hours: $totalHours\n',
             style: const TextStyle(
               decoration: TextDecoration.none,
-              color: Colors.white
               ),
             ),
             TextSpan(
             text: 'Category: $category',
             style: const TextStyle(
               decoration: TextDecoration.none,
-              color: Colors.white
               ),
             ),
           ],
@@ -188,7 +184,6 @@ BarTouchData getBarWeekTouch(Map<String, Map<String, Map<String, dynamic>>> data
     },
     //Loads tooltip containing total hours for the day
     touchTooltipData: BarTouchTooltipData(
-      getTooltipColor: (_) => Colors.blueGrey,
       tooltipPadding: const EdgeInsets.all(8.0),
       tooltipMargin: 8.0,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -197,7 +192,6 @@ BarTouchData getBarWeekTouch(Map<String, Map<String, Map<String, dynamic>>> data
           'Total Hours\n',
           const TextStyle(
             decoration: TextDecoration.none,
-            color: Colors.white,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
@@ -206,7 +200,6 @@ BarTouchData getBarWeekTouch(Map<String, Map<String, Map<String, dynamic>>> data
             text: '${totalHours.toStringAsFixed(1)} hrs',
             style: const TextStyle(
               decoration: TextDecoration.none,
-              color: Colors.white
               ),
             ),
           ],
@@ -226,7 +219,6 @@ Widget bottomAppTitles(double value, TitleMeta meta) {
   const style = TextStyle(
     decoration: TextDecoration.none,
     fontSize: 10.0, 
-    color: Colors.black,
   );
   String text = availableApps[value.toInt()];
   return SideTitleWidget(
@@ -258,7 +250,6 @@ Widget bottomDayTitles(double value, TitleMeta meta) {
   const style = TextStyle(
     decoration: TextDecoration.none,
     fontSize: 10.0, 
-    color: Colors.black,
   );
   String text = availableDays[value.toInt()].substring(0,3);
   return SideTitleWidget(
@@ -282,7 +273,6 @@ Widget sideTitles(double value, TitleMeta meta) {
     style: const TextStyle(
       decoration: TextDecoration.none,
       fontSize: 10,
-      color: Colors.black,
     ),
   );
 }

--- a/lib/pages/graph/widget.dart
+++ b/lib/pages/graph/widget.dart
@@ -41,6 +41,22 @@ List<BarChartGroupData> generateWeeklyChart(Map<String, Map<String, Map<String, 
       generatedWeeklyGroupData(i, data[availableDays[i]]!)
   ]; 
 }
+ 
+
+double tallestDayBar(Map<String, Map<String, Map<String, dynamic>>> data) {
+  double tallestHeight = 0;
+  for (int i = 0; i < data.length; i++) {
+    Map<String, Map<String, dynamic>> dayData = data[availableDays[i]]!;
+    double dayHeight = 0;
+    for (var appName in dayData.keys) {
+      dayHeight += dayData[appName]?['hours'] ?? 0.0;
+    }
+    if (tallestHeight < dayHeight) {
+      tallestHeight = dayHeight;
+    }
+  }
+  return tallestHeight;
+}
 
 ///*********************************
 /// Name: generatedWeeklyGroupData
@@ -68,13 +84,16 @@ BarChartGroupData generatedWeeklyGroupData(int index, Map<String, Map<String, dy
   //Returns the entire stacked bar
   return BarChartGroupData(
     x: index,
+    showingTooltipIndicators: [0],
     barRods: [
       BarChartRodData(
         fromY: 0,
         toY: cumulativeHeight, 
         rodStackItems: rodStackItems, 
-        width: 15, 
-        borderRadius: BorderRadius.circular(5),
+        width: 35, 
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(8.0), 
+          topRight: Radius.circular(8.0)),
       ),
     ],
   );
@@ -94,7 +113,7 @@ List<BarChartGroupData> generateDailyChart(Map<String, Map<String, dynamic>> dat
   ]; 
 }
 
-double tallestBar(Map<String, Map<String, dynamic>> data) {
+double tallestAppBar(Map<String, Map<String, dynamic>> data) {
   double tallestHeight = 0;
   for (int i = 0; i < data.length; i++) {
     Map<String, dynamic> appData = data[data.keys.toList()[i]]!;
@@ -149,7 +168,7 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
       tooltipPadding: EdgeInsets.zero,
       tooltipMargin: -10,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
-        double totalHours = rod.toY;
+        String totalHours = rod.toY.toStringAsFixed(2);        
         return BarTooltipItem(
           "$totalHours\n",
           const TextStyle(
@@ -171,37 +190,23 @@ BarTouchData getBarDayTouch(Map<String, Map<String, String>> data, void Function
 /// loads listview of daily data
 ///*********************************
 BarTouchData getBarWeekTouch(Map<String, Map<String, Map<String, dynamic>>> data, void Function(String) onDaySelected) {
-  return BarTouchData(
+return BarTouchData(
     enabled: true,
-    //Reads touch and updates the selectedDay to load list view
-    touchCallback: (event, response){
-      if (response != null && response.spot != null) {
-        int dayIndex = response.spot!.touchedBarGroupIndex;
-        String day = availableDays[dayIndex];
-        onDaySelected(day);
-      }
-    },
-    //Loads tooltip containing total hours for the day
+    //Loads app data on touch of specific bar
     touchTooltipData: BarTouchTooltipData(
-      tooltipPadding: const EdgeInsets.all(8.0),
-      tooltipMargin: 8.0,
+      fitInsideHorizontally: true,
+      fitInsideVertically: true,
+      getTooltipColor: (group) => Colors.transparent,
+      tooltipPadding: EdgeInsets.zero,
+      tooltipMargin: -10,
       getTooltipItem: (group, groupIndex, rod, rodIndex) {
-        double totalHours = rod.toY;
+        String totalHours = rod.toY.toStringAsFixed(2);
         return BarTooltipItem(
-          'Total Hours\n',
+          "$totalHours\n",
           const TextStyle(
-            decoration: TextDecoration.none,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
-          children: [
-            TextSpan(
-            text: '${totalHours.toStringAsFixed(1)} hrs',
-            style: const TextStyle(
-              decoration: TextDecoration.none,
-              ),
-            ),
-          ],
         );
       },
     )

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -112,7 +112,6 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       extendBodyBehindAppBar: true,
       appBar: AppBar(
-        backgroundColor: Colors.transparent,
         actions: [
           // Creating little user icon you can press to view account info
           IconButton(
@@ -140,9 +139,8 @@ class _MyHomePageState extends State<MyHomePage> {
               height: 100,
               child:  DrawerHeader(
               decoration: BoxDecoration(
-                color: Colors.blueGrey,
               ),
-              child: Center(child: Text("Other Pages:", style: TextStyle(color: Colors.white))),
+              child: Center(child: Text("Other Pages:")),
               ),
             ),
             ListTile(
@@ -174,19 +172,18 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Column(
         children: [ 
           Expanded(
+            flex: 6,
             //Container holding graph in top portion of screen
             child: Scaffold(
               body: [
                 //Daily Graph
                 Container(
                   padding: const EdgeInsets.all(4.0),
-                  color: Colors.indigo.shade50,
                   child: DailyGraphView(onFilteredData: updateFilteredDayData, onBarSelected: updateSelectedBar),
                 ),
                 //Weekly Graph
                  Container(
                   padding: const EdgeInsets.all(4.0),
-                  color: Colors.indigo.shade50,
                   child: WeeklyGraphView(onFilteredData: updateFilteredWeekData, onBarSelected: updateSelectedBar),
                 ),
                 //Monthly Graph
@@ -201,7 +198,6 @@ class _MyHomePageState extends State<MyHomePage> {
                 height: 50,
                 child: NavigationBar(
                   selectedIndex: graphIndex,
-                  backgroundColor: Colors.indigo.shade50,
                   onDestinationSelected: (int index) {
                     setState(() {
                       selectedBar == "null";
@@ -228,10 +224,10 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           const SizedBox(height: 4.0),
           Expanded(
+            flex: 4,
             //Container holding list view in bottom portion of screen
             child: Container(
               padding: const EdgeInsets.all(4.0),
-              color: Colors.indigo.shade100,
               child: ExpandedListView(dayFilteredData: dayData, weekFilteredData: weekData, selectedBar: selectedBar, appColors: appNameToColor, graphIndex: graphIndex),
             ),
           ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -57,7 +57,7 @@ class HomePage extends StatelessWidget {
           Navigator.pushReplacementNamed(context, '/friendsPage');
         }
       },
-      child: Container(padding: const EdgeInsets.all(0.0), child: MyHomePage())
+      child: Container(padding: const EdgeInsets.all(4.0), child: MyHomePage())
     );
   }
 }
@@ -109,8 +109,10 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    //Screensize
+    double? screenWidth = MediaQuery.of(context).size.width;
+    double? screenHeight = MediaQuery.of(context).size.height;
     return Scaffold(
-      extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: Text("ProcrastiStats"),
         actions: [
@@ -134,41 +136,39 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       drawer: Drawer(
         child: ListView(
-          padding: EdgeInsets.zero,
+          padding: EdgeInsets.all(4.0),
           children: <Widget>[
             SizedBox(
-              height: 80,
-              child:  DrawerHeader(
-              decoration: BoxDecoration(
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(12.0),
-                    child: Image.asset("assets/logo.jpg"),
-                  ),
-                  Text("ProcrastiTools",),
-              ],
-              )
+              height: screenHeight * .15,
+              child: DrawerHeader(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text("ProcrastiTools",),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(12.0),
+                      child: Image.asset("assets/logo.jpg"),
+                    ),
+                  ],
+                )
               ),
             ),
-              ListTile(
+            ListTile(
               trailing: Icon(Icons.calendar_today),
               title: Text("Calendar"),
               onTap:() {
                 Navigator.pushNamed(context, '/calendarPage');
               },
             ),
-           // const Divider(),
-             ListTile(
+            const Divider(),
+            ListTile(
               trailing: Icon(Icons.school),
               title: Text("Study Mode"),
               onTap: () {
                 Navigator.pushNamed(context, '/studyModePage');
               },
             ),
-            //const Divider(),
+            const Divider(),
             ListTile(
               trailing: Icon(Icons.alarm),
               title: Text("App Limits"),
@@ -192,45 +192,62 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: DailyGraphView(onFilteredData: updateFilteredDayData, onBarSelected: updateSelectedBar),
                 ),
                 //Weekly Graph
-                 Container(
+                Container(
                   padding: const EdgeInsets.all(4.0),
                   child: WeeklyGraphView(onFilteredData: updateFilteredWeekData, onBarSelected: updateSelectedBar),
                 ),
-                //Monthly Graph
-                 /*Container(
-                  padding: const EdgeInsets.all(4.0),
-                  color: Colors.indigo.shade50,
-                  child: Center(child: Text("Monthly Graph Display"),)
-                  //MonthlyGraphView(onBarSelected: updateSelectedBar),
-                ),*/
               ][graphIndex],
-              bottomNavigationBar: SizedBox(
-                height: 50,
-                child: NavigationBar(
-                  selectedIndex: graphIndex,
-                  onDestinationSelected: (int index) {
-                    setState(() {
-                      selectedBar == "null";
-                      graphIndex = index;
-                    }); 
-                  },
-                  destinations: const <Widget>[
-                    NavigationDestination(
-                      icon: Icon(Icons.calendar_today_rounded), 
-                      label: 'Daily'
+              bottomNavigationBar: Container(
+                height: 72,
+                child: Column(
+                  children: [
+                    Container(color: Color(0xFF1F6FEB), height: 2,),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        Card(
+                          color: graphIndex == 0? Color(0xFF388BFD) : null,
+                          elevation: 3,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
+                          child: IconButton(
+                            padding: EdgeInsets.zero,
+                            icon: Icon(
+                              Icons.calendar_today_rounded,
+                              color: graphIndex == 0? Color(0xFF0D1117) : null,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                selectedBar = "null";
+                                graphIndex = 0;
+                              }); 
+                            },
+                          ), 
+                        ),
+                        Card(
+                          color: graphIndex == 1? Color(0xFF388BFD) : null,
+                          elevation: 3,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
+                          child: IconButton(
+                            padding: EdgeInsets.zero,
+                            icon: Icon(
+                              Icons.calendar_view_week_rounded,
+                              color: graphIndex == 1? Color(0xFF0D1117) : null,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                               selectedBar = "null";
+                                graphIndex = 1;
+                              }); 
+                            },
+                          ), 
+                        ),
+                      ],
                     ),
-                    NavigationDestination(
-                      icon: Icon(Icons.calendar_view_week_rounded), 
-                      label: 'Weekly'
-                    ),
-                    /*NavigationDestination(
-                      icon: Icon(Icons.calendar_month_rounded), 
-                      label: 'Monthly'
-                    ),*/
-                  ],  
-                ), 
-              )         
-            )
+                    Container(color: Color(0xFF1F6FEB), height: 2,),
+                  ],
+                ),
+              ),
+            )         
           ),
           const SizedBox(height: 4.0),
           Expanded(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -160,7 +160,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 Navigator.pushNamed(context, '/calendarPage');
               },
             ),
-            const Divider(),
+            const Divider(height: 1, color: lightBeige,),
             ListTile(
               trailing: Icon(Icons.school),
               title: Text("Study Mode"),
@@ -168,7 +168,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 Navigator.pushNamed(context, '/studyModePage');
               },
             ),
-            const Divider(),
+            const Divider(height: 1, color: lightBeige,),
             ListTile(
               trailing: Icon(Icons.alarm),
               title: Text("App Limits"),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -182,18 +182,16 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Column(
         children: [ 
           Expanded(
-            flex: 6,
+            flex: 13,
             //Container holding graph in top portion of screen
             child: Scaffold(
               body: [
                 //Daily Graph
                 Container(
-                  padding: const EdgeInsets.all(4.0),
                   child: DailyGraphView(onFilteredData: updateFilteredDayData, onBarSelected: updateSelectedBar),
                 ),
                 //Weekly Graph
                 Container(
-                  padding: const EdgeInsets.all(4.0),
                   child: WeeklyGraphView(onFilteredData: updateFilteredWeekData, onBarSelected: updateSelectedBar),
                 ),
               ][graphIndex],
@@ -251,7 +249,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           const SizedBox(height: 4.0),
           Expanded(
-            flex: 4,
+            flex: 7,
             //Container holding list view in bottom portion of screen
             child: Container(
               padding: const EdgeInsets.all(4.0),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -57,7 +57,7 @@ class HomePage extends StatelessWidget {
           Navigator.pushReplacementNamed(context, '/friendsPage');
         }
       },
-      child: Container(padding: const EdgeInsets.all(4.0), child: MyHomePage())
+      child: Container(padding: const EdgeInsets.all(0.0), child: MyHomePage())
     );
   }
 }
@@ -207,37 +207,55 @@ class _MyHomePageState extends State<MyHomePage> {
                           color: graphIndex == 0? beige : null,
                           elevation: 3,
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
-                          child: IconButton(
-                            padding: EdgeInsets.zero,
-                            icon: Icon(
-                              Icons.calendar_today_rounded,
-                              color: graphIndex == 0? lightBlue : null,
-                            ),
-                            onPressed: () {
-                              setState(() {
-                                selectedBar = "null";
-                                graphIndex = 0;
-                              }); 
-                            },
-                          ), 
+                          child: InkWell(
+                            child: Padding(
+                              padding: EdgeInsets.all(5.0),
+                              child: Row(
+                            children: [
+                              Icon(
+                                Icons.calendar_today_rounded,
+                                color: graphIndex == 0? lightBlue : lightBeige,
+                                size: screenHeight * 0.035,
+                              ),
+                              Text("  Daily  ", style: TextStyle(color: graphIndex == 0? darkBlue : null)),
+                            ],
+                          ),
+                            ), 
+                        
+                          onTap: () {
+                             setState(() {
+                              selectedBar = "null";
+                              graphIndex = 0;
+                            }); 
+                          },
+                          ),
                         ),
                         Card(
                           color: graphIndex == 1? beige : null,
                           elevation: 3,
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
-                          child: IconButton(
-                            padding: EdgeInsets.zero,
-                            icon: Icon(
-                              Icons.calendar_view_week_rounded,
-                              color: graphIndex == 1? lightBlue : null,
-                            ),
-                            onPressed: () {
-                              setState(() {
-                               selectedBar = "null";
-                                graphIndex = 1;
-                              }); 
-                            },
-                          ), 
+                          child: InkWell(
+                            child: Padding(
+                              padding: EdgeInsets.all(5.0),
+                              child: Row(
+                            children: [
+                              Icon(
+                                Icons.calendar_view_week_rounded,
+                                color: graphIndex == 1? lightBlue : lightBeige,
+                                size: screenHeight * 0.035,
+                              ),
+                              Text("  Weekly  ", style: TextStyle(color: graphIndex == 1? darkBlue : null)),
+                            ],
+                          ),
+                            ), 
+                        
+                          onTap: () {
+                             setState(() {
+                              selectedBar = "null";
+                              graphIndex = 1;
+                            }); 
+                          },
+                          ),
                         ),
                       ],
                     ),
@@ -247,14 +265,10 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
             )         
           ),
-          const SizedBox(height: 4.0),
           Expanded(
             flex: 7,
             //Container holding list view in bottom portion of screen
-            child: Container(
-              padding: const EdgeInsets.all(4.0),
-              child: ExpandedListView(dayFilteredData: dayData, weekFilteredData: weekData, selectedBar: selectedBar, appColors: appNameToColor, graphIndex: graphIndex),
-            ),
+            child: ExpandedListView(dayFilteredData: dayData, weekFilteredData: weekData, selectedBar: selectedBar, appColors: appNameToColor, graphIndex: graphIndex),
           ),
         ],
       ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -112,6 +112,7 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       extendBodyBehindAppBar: true,
       appBar: AppBar(
+        title: Text("ProcrastiStats"),
         actions: [
           // Creating little user icon you can press to view account info
           IconButton(
@@ -136,29 +137,38 @@ class _MyHomePageState extends State<MyHomePage> {
           padding: EdgeInsets.zero,
           children: <Widget>[
             SizedBox(
-              height: 100,
+              height: 80,
               child:  DrawerHeader(
               decoration: BoxDecoration(
               ),
-              child: Center(child: Text("Other Pages:")),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12.0),
+                    child: Image.asset("assets/logo.jpg"),
+                  ),
+                  Text("ProcrastiTools",),
+              ],
+              )
               ),
             ),
-            ListTile(
+              ListTile(
               trailing: Icon(Icons.calendar_today),
               title: Text("Calendar"),
               onTap:() {
                 Navigator.pushNamed(context, '/calendarPage');
               },
             ),
-            const Divider(),
-            ListTile(
+           // const Divider(),
+             ListTile(
               trailing: Icon(Icons.school),
               title: Text("Study Mode"),
               onTap: () {
                 Navigator.pushNamed(context, '/studyModePage');
               },
             ),
-            const Divider(),
+            //const Divider(),
             ListTile(
               trailing: Icon(Icons.alarm),
               title: Text("App Limits"),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -201,19 +201,19 @@ class _MyHomePageState extends State<MyHomePage> {
                 height: 72,
                 child: Column(
                   children: [
-                    Container(color: Color(0xFF1F6FEB), height: 2,),
+                    Container(color: beige, height: 2,),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceAround,
                       children: [
                         Card(
-                          color: graphIndex == 0? Color(0xFF388BFD) : null,
+                          color: graphIndex == 0? beige : null,
                           elevation: 3,
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
                           child: IconButton(
                             padding: EdgeInsets.zero,
                             icon: Icon(
                               Icons.calendar_today_rounded,
-                              color: graphIndex == 0? Color(0xFF0D1117) : null,
+                              color: graphIndex == 0? lightBlue : null,
                             ),
                             onPressed: () {
                               setState(() {
@@ -224,14 +224,14 @@ class _MyHomePageState extends State<MyHomePage> {
                           ), 
                         ),
                         Card(
-                          color: graphIndex == 1? Color(0xFF388BFD) : null,
+                          color: graphIndex == 1? beige : null,
                           elevation: 3,
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
                           child: IconButton(
                             padding: EdgeInsets.zero,
                             icon: Icon(
                               Icons.calendar_view_week_rounded,
-                              color: graphIndex == 1? Color(0xFF0D1117) : null,
+                              color: graphIndex == 1? lightBlue : null,
                             ),
                             onPressed: () {
                               setState(() {
@@ -243,7 +243,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         ),
                       ],
                     ),
-                    Container(color: Color(0xFF1F6FEB), height: 2,),
+                    Container(color: beige, height: 2,),
                   ],
                 ),
               ),

--- a/lib/pages/leaderboard_page.dart
+++ b/lib/pages/leaderboard_page.dart
@@ -44,7 +44,7 @@ class _LeaderBoardPageState extends State<LeaderBoardPage> {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: Text("ProcrastiStats"),
+          title: Text("ProcrastiBoards"),
         actions: [
           // Creating little user icon you can press to view account info
           IconButton(

--- a/lib/pages/leaderboard_page.dart
+++ b/lib/pages/leaderboard_page.dart
@@ -168,7 +168,7 @@ class _LeaderBoardPageState extends State<LeaderBoardPage> {
                       title: Text(user['displayName']),
                       subtitle: Text(
                         'Daily Hours: ${(user['totalDailyHours'] as num).toStringAsFixed(2)}',
-                        style: const TextStyle(color: Colors.grey),
+                        //style: const TextStyle(color: Colors.grey),
                       ),
                       trailing: Text("${index+1}"),
                     );

--- a/lib/pages/leaderboard_page.dart
+++ b/lib/pages/leaderboard_page.dart
@@ -44,7 +44,26 @@ class _LeaderBoardPageState extends State<LeaderBoardPage> {
       },
       child: Scaffold(
         appBar: AppBar(
-          
+          title: Text("ProcrastiStats"),
+        actions: [
+          // Creating little user icon you can press to view account info
+          IconButton(
+            icon: CircleAvatar(
+              backgroundImage: NetworkImage(
+                // Use user's pfp as icon image if there is no pfp use this link as a default
+                auth.currentUser?.photoURL ?? 'https://picsum.photos/id/237/200/300',
+              ),
+            ),
+            onPressed: () async {
+              await Navigator.pushNamed(context, "/profileSettings");
+              // Reload the user in case anything changed
+              await auth.currentUser?.reload();
+              // Reload UI in case things changed
+              setState(() {});
+            },
+          )
+        ],
+        bottom: AppBar(
           title: Text(showFriendsLeaderboard ? "Friends Leaderboard" : "Global Leaderboard"),
           automaticallyImplyLeading: false,
           actions: [
@@ -58,7 +77,55 @@ class _LeaderBoardPageState extends State<LeaderBoardPage> {
               },
             ),
           ],
+          ),
         ),
+        drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            SizedBox(
+              height: 80,
+              child:  DrawerHeader(
+              decoration: BoxDecoration(
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12.0),
+                    child: Image.asset("assets/logo.jpg"),
+                  ),
+                  Text("ProcrastiTools",),
+              ],
+              )
+              ),
+            ),
+              ListTile(
+              trailing: Icon(Icons.calendar_today),
+              title: Text("Calendar"),
+              onTap:() {
+                Navigator.pushNamed(context, '/calendarPage');
+              },
+            ),
+           // const Divider(),
+             ListTile(
+              trailing: Icon(Icons.school),
+              title: Text("Study Mode"),
+              onTap: () {
+                Navigator.pushNamed(context, '/studyModePage');
+              },
+            ),
+            //const Divider(),
+            ListTile(
+              trailing: Icon(Icons.alarm),
+              title: Text("App Limits"),
+              onTap: () {
+                Navigator.pushNamed(context, '/appLimitsPage');
+              },
+            )
+          ],
+        ),
+      ),
         body: FutureBuilder<DocumentSnapshot>(
           future: firestore.collection('UID').doc(currentUserId).get(),
           builder: (context, userSnapshot) {

--- a/lib/profile/profile_settings.dart
+++ b/lib/profile/profile_settings.dart
@@ -248,13 +248,12 @@ class ProfileSettingsState extends State<ProfileSettings> {
                 context: context, 
                 builder: (BuildContext alertContext) => AlertDialog(
                   title: Text("Delete Account"),
-                  content: Text("Are you sure you want to delete your account?\n\nThis action cannot be undone and will"
-                    " clear all of your data from our database."),
+                  content: Text("Are you sure you want to delete your account?\n\nThis action cannot be undone."),
                   actions: [
                     ElevatedButton(
                       onPressed: (){
                         Navigator.pop(alertContext, "Delete Account");
-                        _deleteAccount;
+                        _deleteAccount();
                       },
                       child: Text("Yes")
                     ),


### PR DESCRIPTION
Full ThemeData implemented for all color schemes and widgets. 

AppBar redesign:
Implemented app bar across all main screens
Added titles for each main screen
Drawer redesigned to occupy more space 

Home Page:
Full overhaul of graph UI with the purpose of being easy to read and tap
Tooltips no longer require tap and appear above bar
Graph resized itself to next largest whole number of the tallest bar
Ratio of views changed from 1:1 to 13:7
Bottom nav bar for switch graph views removed and custom made from scratch
Ability to see total daily hours and points on the current phone usage screen(first page)
List view layout redesigned
Naming of text widgets redone
